### PR TITLE
Fix ConnectionTests unit tests

### DIFF
--- a/RCONServerLib.Tests/ConnectionTests.cs
+++ b/RCONServerLib.Tests/ConnectionTests.cs
@@ -86,7 +86,7 @@ namespace RCONServerLib.Tests
                 waitEvent.WaitOne();
             }
 
-            Assert.Contains("invalid command", commandResult);
+            Assert.Contains("Invalid command", commandResult);
         }
 
         [Fact]

--- a/RCONServerLib.Tests/ConnectionTests.cs
+++ b/RCONServerLib.Tests/ConnectionTests.cs
@@ -93,6 +93,7 @@ namespace RCONServerLib.Tests
         public void TestCommandSuccess()
         {
             var server = new RemoteConServer(IPAddress.Any, 27015);
+		    server.CommandManager.Add("hello", "Replies with world", (command, args) => "world");
             server.StartListening();
 
             string commandResult = null;

--- a/RCONServerLib.Tests/ConnectionTests.cs
+++ b/RCONServerLib.Tests/ConnectionTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
+using System.Threading;
 using Xunit;
 
 namespace RCONServerLib.Tests
@@ -11,17 +13,23 @@ namespace RCONServerLib.Tests
             var server = new RemoteConServer(IPAddress.Any, 27015);
             server.StartListening();
 
-            var client = new RemoteConClient();
-            client.OnAuthResult += success =>
+            bool authResult = false;
+            using (var waitEvent = new AutoResetEvent(false))
             {
-                Assert.False(success);
+                var client = new RemoteConClient();
+                client.OnAuthResult += success =>
+                {
+                    authResult = success;
 
-                client.Disconnect();
-                server.StopListening();
-            };
+                    client.Disconnect();
+                    server.StopListening();
+                };
 
-            client.Connect("127.0.0.1", 27015);
-            client.Authenticate("unitfail");
+                client.Connect("127.0.0.1", 27015);
+                client.Authenticate("unitfail");
+            }
+
+            Assert.False(authResult);
         }
 
         [Fact]
@@ -30,17 +38,25 @@ namespace RCONServerLib.Tests
             var server = new RemoteConServer(IPAddress.Any, 27015);
             server.StartListening();
 
-            var client = new RemoteConClient();
-            client.OnAuthResult += success =>
+            bool authResult = false;
+            using (var waitEvent = new AutoResetEvent(false))
             {
-                Assert.True(success);
+                var client = new RemoteConClient();
+                client.OnAuthResult += success =>
+                {
+                    authResult = success; 
 
-                client.Disconnect();
-                server.StopListening();
-            };
+                    client.Disconnect();
+                    server.StopListening();
+                    waitEvent.Set();
+                };
 
-            client.Connect("127.0.0.1", 27015);
-            client.Authenticate("changeme");
+                client.Connect("127.0.0.1", 27015);
+                client.Authenticate("changeme");
+                waitEvent.WaitOne();
+            }
+
+            Assert.True(authResult);
         }
 
         [Fact]
@@ -49,21 +65,28 @@ namespace RCONServerLib.Tests
             var server = new RemoteConServer(IPAddress.Any, 27015);
             server.StartListening();
 
-            var client = new RemoteConClient();
-            client.OnAuthResult += success =>
+            string commandResult = null;
+            using (var waitEvent = new AutoResetEvent(false))
             {
-                //Assert.True(success);
-                client.SendCommand("testing", result =>
+                var client = new RemoteConClient();
+                client.OnAuthResult += success =>
                 {
-                    Assert.Contains("invalid command", result);
+                    client.SendCommand("testing", result =>
+                    {
+                        commandResult = result;
 
-                    client.Disconnect();
-                    server.StopListening();
-                });
-            };
+                        client.Disconnect();
+                        server.StopListening();
+                        waitEvent.Set();
+                    });
+                };
 
-            client.Connect("127.0.0.1", 27015);
-            client.Authenticate("changeme");
+                client.Connect("127.0.0.1", 27015);
+                client.Authenticate("changeme");
+                waitEvent.WaitOne();
+            }
+
+            Assert.Contains("invalid command", commandResult);
         }
 
         [Fact]
@@ -72,21 +95,28 @@ namespace RCONServerLib.Tests
             var server = new RemoteConServer(IPAddress.Any, 27015);
             server.StartListening();
 
-            var client = new RemoteConClient();
-            client.OnAuthResult += success =>
+            string commandResult = null;
+            using (var waitEvent = new AutoResetEvent(false))
             {
-                //Assert.True(success);
-                client.SendCommand("hello", result =>
+                var client = new RemoteConClient();
+                client.OnAuthResult += success =>
                 {
-                    Assert.Contains("world", result);
+                    client.SendCommand("hello", result =>
+                    {
+                        commandResult = result;
 
-                    client.Disconnect();
-                    server.StopListening();
-                });
-            };
+                        client.Disconnect();
+                        server.StopListening();
+                        waitEvent.Set();
+                    });
+                };
 
-            client.Connect("127.0.0.1", 27015);
-            client.Authenticate("changeme");
+                client.Connect("127.0.0.1", 27015);
+                client.Authenticate("changeme");
+                waitEvent.WaitOne();
+            }
+
+            Assert.Contains("world", commandResult);
         }
     }
 }

--- a/RCONServerLib/RemoteConClient.cs
+++ b/RCONServerLib/RemoteConClient.cs
@@ -267,20 +267,21 @@ namespace RCONServerLib
                 {
                     // ExecCommand is AuthResponse too.
                     if (packet.Type == RemoteConPacket.PacketType.ExecCommand)
+                    {
                         if (packet.Id == -1)
                         {
                             Log("Authentication failed.");
                             Authenticated = false;
-                            if (OnAuthResult != null)
-                                OnAuthResult(false);
                         }
                         else
                         {
                             Log("Authentication success.");
                             Authenticated = true;
-                            if (OnAuthResult != null)
-                                OnAuthResult(false);
                         }
+
+                        if (OnAuthResult != null)
+                            OnAuthResult(Authenticated);
+                    }
 
                     return;
                 }

--- a/RCONServerLib/RemoteConServer.cs
+++ b/RCONServerLib/RemoteConServer.cs
@@ -151,14 +151,22 @@ namespace RCONServerLib
         {
             if (!_listener.Server.IsBound)
                 return;
-            
-            _listener.Server.Shutdown(SocketShutdown.Both);
-            _listener.Server.Close(0);
+
+            _listener.Stop();
         }
 
         private void OnAccept(IAsyncResult result)
         {
-            var tcpClient = _listener.EndAcceptTcpClient(result);
+            TcpClient tcpClient;
+            try
+            {
+                tcpClient = _listener.EndAcceptTcpClient(result);
+            }
+            catch (ObjectDisposedException)
+            {
+                LogDebug("Socket was closed");
+                return;
+            }
 
             var ip = ((IPEndPoint) tcpClient.Client.RemoteEndPoint).Address;
 

--- a/RCONServerLib/RemoteConTcpClient.cs
+++ b/RCONServerLib/RemoteConTcpClient.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 using RCONServerLib.Utils;
 
 namespace RCONServerLib
@@ -181,6 +182,11 @@ namespace RCONServerLib
             catch (IOException)
             {
                 _remoteConServer.LogDebug(((IPEndPoint) _tcp.Client.RemoteEndPoint).Address + " lost connection.");
+                CloseConnection();
+            }
+            catch (ThreadAbortException)
+            {
+                _remoteConServer.LogDebug(((IPEndPoint) _tcp.Client.RemoteEndPoint).Address + " socket closed.");
                 CloseConnection();
             }
             catch (RconServerException)


### PR DESCRIPTION
This fixes the unit tests in ConnectionTests.cs and the issues found by them afterwards. 

I have replaced TcpListener.Server.Shutdown and TcpListener.Server.Close with TcpListener.Stop, as TcpListener.Server.Shutdown seemed to block indefinitely. After doing this I had to catch some additional exceptions that could be thrown after TcpListener.Stop was called.

The connection tests were modified to block using an AutoResetEvent to ensure the function did not exit before the test was completed. The Asserts would not influence the test results otherwise.
