### PR TITLE
Unicode support

### DIFF
--- a/RCONServerLib.Tests/ConnectionTests.cs
+++ b/RCONServerLib.Tests/ConnectionTests.cs
@@ -7,16 +7,20 @@ namespace RCONServerLib.Tests
 {
     public class ConnectionTests
     {
-        [Fact]
-        public void TestAuthFail()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TestAuthFail(bool useUTF8)
         {
             var server = new RemoteConServer(IPAddress.Any, 27015);
+            server.UseUTF8 = useUTF8;
             server.StartListening();
 
             bool authResult = false;
             using (var waitEvent = new AutoResetEvent(false))
             {
                 var client = new RemoteConClient();
+                client.UseUTF8 = useUTF8;
                 client.OnAuthResult += success =>
                 {
                     authResult = success;
@@ -34,16 +38,20 @@ namespace RCONServerLib.Tests
             Assert.False(authResult);
         }
 
-        [Fact]
-        public void TestAuthSuccess()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TestAuthSuccess(bool useUTF8)
         {
             var server = new RemoteConServer(IPAddress.Any, 27015);
+            server.UseUTF8 = useUTF8;
             server.StartListening();
 
             bool authResult = false;
             using (var waitEvent = new AutoResetEvent(false))
             {
                 var client = new RemoteConClient();
+                client.UseUTF8 = useUTF8;
                 client.OnAuthResult += success =>
                 {
                     authResult = success; 
@@ -61,16 +69,20 @@ namespace RCONServerLib.Tests
             Assert.True(authResult);
         }
 
-        [Fact]
-        public void TestCommandFail()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TestCommandFail(bool useUTF8)
         {
             var server = new RemoteConServer(IPAddress.Any, 27015);
             server.StartListening();
+            server.UseUTF8 = useUTF8;
 
             string commandResult = null;
             using (var waitEvent = new AutoResetEvent(false))
             {
                 var client = new RemoteConClient();
+                client.UseUTF8 = useUTF8;
                 client.OnAuthResult += success =>
                 {
                     client.SendCommand("testing", result =>
@@ -91,17 +103,21 @@ namespace RCONServerLib.Tests
             Assert.Contains("Invalid command", commandResult);
         }
 
-        [Fact]
-        public void TestCommandSuccess()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TestCommandSuccess(bool useUTF8)
         {
             var server = new RemoteConServer(IPAddress.Any, 27015);
 		    server.CommandManager.Add("hello", "Replies with world", (command, args) => "world");
+            server.UseUTF8 = true;
             server.StartListening();
 
             string commandResult = null;
             using (var waitEvent = new AutoResetEvent(false))
             {
                 var client = new RemoteConClient();
+                client.UseUTF8 = useUTF8;
                 client.OnAuthResult += success =>
                 {
                     client.SendCommand("hello", result =>

--- a/RCONServerLib.Tests/ConnectionTests.cs
+++ b/RCONServerLib.Tests/ConnectionTests.cs
@@ -23,10 +23,12 @@ namespace RCONServerLib.Tests
 
                     client.Disconnect();
                     server.StopListening();
+                    waitEvent.Set();
                 };
 
                 client.Connect("127.0.0.1", 27015);
                 client.Authenticate("unitfail");
+                waitEvent.WaitOne();
             }
 
             Assert.False(authResult);

--- a/RCONServerLib.Tests/RemoteConTests.cs
+++ b/RCONServerLib.Tests/RemoteConTests.cs
@@ -6,11 +6,14 @@ namespace RCONServerLib.Tests
 {
     public class RemoteConTests
     {
-	    [Fact]
-	    public void RemoteConInvalidAuthPacketTypeTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RemoteConInvalidAuthPacketTypeTest(bool useUTF8)
 	    {
 		    var server = new RemoteConServer(IPAddress.Any, 27015);
 		    server.CommandManager.Add("test", "Test", (command, args) => "test");
+            server.UseUTF8 = useUTF8;
 		    
 		    var client = new RemoteConTcpClient(server);
 		    
@@ -27,12 +30,15 @@ namespace RCONServerLib.Tests
 			    });
 		    });
 	    }
-	    
-	    [Fact]
-	    public void RemoteConAuthFailureTest()
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RemoteConAuthFailureTest(bool useUTF8)
 	    {
 		    var server = new RemoteConServer(IPAddress.Any, 27015);
 		    server.CommandManager.Add("test", "Test", (command, args) => "test");
+            server.UseUTF8 = useUTF8;
 		    
 		    var client = new RemoteConTcpClient(server);
 		    
@@ -47,14 +53,17 @@ namespace RCONServerLib.Tests
 		    });
 	    }
 
-	    [Fact]
-	    public void RemoteConAuthSuccessTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RemoteConAuthSuccessTest(bool useUTF8)
 	    {
 		    var server = new RemoteConServer(IPAddress.Any, 27015)
 		    {
 			    Password = "supersecretpassword"
 		    };
 		    server.CommandManager.Add("test", "Test", (command, args) => "test");
+            server.UseUTF8 = useUTF8;
 		    
 		    var client = new RemoteConTcpClient(server);
 		    
@@ -69,11 +78,14 @@ namespace RCONServerLib.Tests
 		    });
 	    }
 
-	    [Fact]
-	    public void RemoteConInvalidCommandTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RemoteConInvalidCommandTest(bool useUTF8)
 	    {
 		    var server = new RemoteConServer(IPAddress.Any, 27015);
 		    server.CommandManager.Add("test", "Test", (command, args) => "test");
+            server.UseUTF8 = useUTF8;
 		    
 		    var client = new RemoteConTcpClient(server);
 		    client.Authenticated = true;
@@ -89,11 +101,14 @@ namespace RCONServerLib.Tests
 		    });
 	    }
 
-	    [Fact]
-	    public void RemoteConCommandTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RemoteConCommandTest(bool useUTF8)
 	    {
 		    var server = new RemoteConServer(IPAddress.Any, 27015);
 		    server.CommandManager.Add("test", "Test", (command, args) => "test");
+            server.UseUTF8 = useUTF8;
 		    
 		    var client = new RemoteConTcpClient(server);
 		    client.Authenticated = true;
@@ -109,11 +124,14 @@ namespace RCONServerLib.Tests
 		    });
 	    }
 
-	    [Fact]
-	    public void RemoteConEmptyPayloadTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RemoteConEmptyPayloadTest(bool useUTF8)
 	    {
 		    var server = new RemoteConServer(IPAddress.Any, 27015);
 		    server.CommandManager.Add("test", "Test", (command, args) => "test");
+            server.UseUTF8 = useUTF8;
 		    
 		    var client = new RemoteConTcpClient(server);
 		    client.Authenticated = true;
@@ -131,12 +149,15 @@ namespace RCONServerLib.Tests
 			    });			    
 		    });
 	    }
-	    
-	    [Fact]
-	    public void RemoteConInvalidPacketTypeTest()
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RemoteConInvalidPacketTypeTest(bool useUTF8)
 	    {
 		    var server = new RemoteConServer(IPAddress.Any, 27015);
 		    server.CommandManager.Add("test", "Test", (command, args) => "test");
+            server.UseUTF8 = useUTF8;
 		    
 		    var client = new RemoteConTcpClient(server);
 		    client.Authenticated = true;

--- a/RCONServerLib.Tests/Tests.cs
+++ b/RCONServerLib.Tests/Tests.cs
@@ -31,6 +31,22 @@ namespace RCONServerLib.Tests
             }, useUTF8));
         }
 
+        [Fact]
+        public void RconPacketTooLongTest()
+        {
+            var bytes = new byte[4096];
+            Array.Copy(new byte[]
+            {
+                0xFC, 0x0F, 0x00, 0x00, // Size - 4092
+                0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00
+            }, 0, bytes, 0, 12);
+            bytes[4094] = 0x00;
+            bytes[4095] = 0x00;
+            for (var i = 13; i < 4094; i++) bytes[i] = 0xFF;
+            Assert.Throws<NullTerminatorMissingException>(() => new RemoteConPacket(bytes));
+        }
+        
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/RCONServerLib.Tests/Tests.cs
+++ b/RCONServerLib.Tests/Tests.cs
@@ -8,14 +8,18 @@ namespace RCONServerLib.Tests
 {
     public class Tests
     {
-        [Fact]
-        public void RconPacketLengthTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RconPacketLengthTest(bool useUTF8)
         {
-            Assert.Throws<LengthMismatchException>(() => new RemoteConPacket(new byte[] {0xFF, 0xFF, 0x00, 0x00}));
+            Assert.Throws<LengthMismatchException>(() => new RemoteConPacket(new byte[] {0xFF, 0xFF, 0x00, 0x00}, useUTF8));
         }
 
-        [Fact]
-        public void RconPacketNullTerminatorEndTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RconPacketNullTerminatorEndTest(bool useUTF8)
         {
             Assert.Throws<NullTerminatorMissingException>(() => new RemoteConPacket(new byte[]
             {
@@ -24,18 +28,20 @@ namespace RCONServerLib.Tests
                 0x00, 0x00, 0x00, 0x00, // Type
                 0x00, // Payload
                 0x01 // Null-terminator end
-            }));
+            }, useUTF8));
         }
 
-        [Fact]
-        public void RconPacketTypeTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RconPacketTypeTest(bool useUTF8)
         {
             Assert.Throws<InvalidPacketTypeException>(() => new RemoteConPacket(new byte[]
             {
                 0x08, 0x00, 0x00, 0x00, // Size
                 0x00, 0x00, 0x00, 0x00, // Id
                 0xFF, 0xFF, 0x00, 0x00 // Type
-            }));
+            }, useUTF8));
         }
 
         [Fact]
@@ -50,8 +56,10 @@ namespace RCONServerLib.Tests
             Assert.False(IpExtension.Match("192.*.*.*", "178.75.68.49"));
         }
 
-        [Fact]
-        public void RconPacketSuccessTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RconPacketSuccessTest(bool useUTF8)
         {
             var packet = new RemoteConPacket(new byte[]
             {
@@ -60,15 +68,17 @@ namespace RCONServerLib.Tests
                 0x03, 0x00, 0x00, 0x00, // Type
                 0x00,
                 0x00,
-            });
+            }, useUTF8);
 
             Assert.Equal(2, packet.Id);
             Assert.Equal(10, packet.Size);
             Assert.Equal(RemoteConPacket.PacketType.Auth, packet.Type);
         }
 
-        [Fact]
-        public void RconPacketGetBytesTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RconPacketGetBytesTest(bool useUTF8)
         {
             var testBytes = new byte[]
             {
@@ -78,7 +88,7 @@ namespace RCONServerLib.Tests
                 0x00,
                 0x00,
             };
-            var packet = new RemoteConPacket(2, RemoteConPacket.PacketType.Auth, "");
+            var packet = new RemoteConPacket(2, RemoteConPacket.PacketType.Auth, "", useUTF8);
 
             var packetBytes = packet.GetBytes();
             for (var index = 0; index < testBytes.Length; index++)

--- a/RCONServerLib.Tests/Tests.cs
+++ b/RCONServerLib.Tests/Tests.cs
@@ -28,22 +28,6 @@ namespace RCONServerLib.Tests
         }
 
         [Fact]
-        public void RconPacketTooLongTest()
-        {
-            var bytes = new byte[4096];
-            Array.Copy(new byte[]
-            {
-                0xFC, 0x0F, 0x00, 0x00, // Size - 4092
-                0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00
-            }, 0, bytes, 0, 12);
-            bytes[4094] = 0x00;
-            bytes[4095] = 0x00;
-            for (var i = 13; i < 4094; i++) bytes[i] = 0xFF;
-            Assert.Throws<NullTerminatorMissingException>(() => new RemoteConPacket(bytes));
-        }
-
-        [Fact]
         public void RconPacketTypeTest()
         {
             Assert.Throws<InvalidPacketTypeException>(() => new RemoteConPacket(new byte[]

--- a/RCONServerLib/RemoteConClient.cs
+++ b/RCONServerLib/RemoteConClient.cs
@@ -74,6 +74,8 @@ namespace RCONServerLib
 
             _packetId = 0;
             _requestedCommands = new Dictionary<int, CommandResult>();
+
+            UseUTF8 = false;
         }
 
         /// <summary>
@@ -83,6 +85,11 @@ namespace RCONServerLib
         {
             get { return _client.Connected; }
         }
+
+        /// <summary>
+        ///     Whether to use UTF8 to encode the packet payload
+        /// </summary>
+        public bool UseUTF8 { get; set; }
 
         /// <summary>
         ///     An event handler when the result of the authentication is received
@@ -165,7 +172,7 @@ namespace RCONServerLib
         public void Authenticate(string password)
         {
             _packetId++;
-            var packet = new RemoteConPacket(_packetId, RemoteConPacket.PacketType.Auth, password);
+            var packet = new RemoteConPacket(_packetId, RemoteConPacket.PacketType.Auth, password, UseUTF8);
             SendPacket(packet);
         }
 
@@ -186,7 +193,7 @@ namespace RCONServerLib
             _packetId++;
             _requestedCommands.Add(_packetId, resultFunc);
 
-            var packet = new RemoteConPacket(_packetId, RemoteConPacket.PacketType.ExecCommand, command);
+            var packet = new RemoteConPacket(_packetId, RemoteConPacket.PacketType.ExecCommand, command, UseUTF8);
             SendPacket(packet);
         }
 
@@ -267,7 +274,7 @@ namespace RCONServerLib
         {
             try
             {
-                var packet = new RemoteConPacket(rawPacket);
+                var packet = new RemoteConPacket(rawPacket, UseUTF8);
                 if (!Authenticated)
                 {
                     // ExecCommand is AuthResponse too.

--- a/RCONServerLib/RemoteConClient.cs
+++ b/RCONServerLib/RemoteConClient.cs
@@ -206,10 +206,8 @@ namespace RCONServerLib
             {
                 _ns.BeginWrite(packetBytes, 0, packetBytes.Length - 1, ar => { _ns.EndWrite(ar); }, null);
             }
-            catch (ObjectDisposedException)
-            {
-                // Do not write to socket when its disposed.
-            }
+            catch (ObjectDisposedException) { } // Do not write to NetworkStream when it's closed.
+            catch (IOException) { } // Do not write to Socket when it's closed.
         }
 
         /// <summary>

--- a/RCONServerLib/RemoteConPacket.cs
+++ b/RCONServerLib/RemoteConPacket.cs
@@ -62,12 +62,8 @@ namespace RCONServerLib
                         throw new InvalidPacketTypeException("Invalid packet type");
                     Type = (PacketType) Enum.ToObject(typeof(PacketType), packetType);
 
-                    Payload = reader.ReadAscii();
-
-                    // Get payload length by subtracting 9 bytes (ID 4-Bytes, Type 4-Bytes, Null-terminator 1-Byte)
-                    if (Encoding.ASCII.GetByteCount(Payload) > Size - 9)
-                        throw new LengthMismatchException("Payload length mismatch");
-
+                    Payload = Encoding.UTF8.GetString(reader.ReadBytes(Size - 10));
+                    reader.ReadByte();
                     var nullTerminator = reader.ReadByte();
                     if (nullTerminator != 0x00)
                         throw new NullTerminatorMissingException("Missing last null-terminator");
@@ -92,7 +88,7 @@ namespace RCONServerLib
         /// </summary>
         public int Length
         {
-            get { return Encoding.ASCII.GetBytes(Payload + '\0').Length + 13; }
+            get { return Encoding.UTF8.GetBytes(Payload + '\0').Length + 13; }
         }
 
         /// <summary>
@@ -105,7 +101,7 @@ namespace RCONServerLib
             {
                 using (var writer = new BinaryWriterExt(ms))
                 {
-                    var bodyBytes = Encoding.ASCII.GetBytes(Payload + '\0');
+                    var bodyBytes = Encoding.UTF8.GetBytes(Payload + '\0');
                     writer.WriteLittleEndian(bodyBytes.Length + 9);
                     writer.WriteLittleEndian(Id);
                     writer.WriteLittleEndian((int) Type);

--- a/RCONServerLib/RemoteConPacket.cs
+++ b/RCONServerLib/RemoteConPacket.cs
@@ -43,8 +43,17 @@ namespace RCONServerLib
         /// </summary>
         public readonly PacketType Type;
 
-        public RemoteConPacket(byte[] packetBytes)
+        /// <summary>
+        ///     Indicates the encoding of the packet payload.
+        ///     Is either ASCII or UTF8
+        /// </summary>
+        private readonly Encoding _packetEncoding = Encoding.ASCII;
+
+        public RemoteConPacket(byte[] packetBytes, bool useUTF8 = false)
         {
+            if (useUTF8)
+                _packetEncoding = Encoding.UTF8;
+
             using (var ms = new MemoryStream(packetBytes))
             {
                 using (var reader = new BinaryReaderExt(ms))
@@ -62,8 +71,20 @@ namespace RCONServerLib
                         throw new InvalidPacketTypeException("Invalid packet type");
                     Type = (PacketType) Enum.ToObject(typeof(PacketType), packetType);
 
-                    Payload = Encoding.UTF8.GetString(reader.ReadBytes(Size - 10));
-                    reader.ReadByte();
+                    if (!useUTF8)
+                    {
+                        Payload = reader.ReadAscii();
+
+                        // Get payload length by subtracting 9 bytes (ID 4-Bytes, Type 4-Bytes, Null-terminator 1-Byte)
+                        if (Encoding.ASCII.GetByteCount(Payload) > Size - 9)
+                            throw new LengthMismatchException("Payload length mismatch");
+                    }
+                    else
+                    {
+                        Payload = Encoding.UTF8.GetString(reader.ReadBytes(Size - 10));
+                        reader.ReadByte();
+                    }
+
                     var nullTerminator = reader.ReadByte();
                     if (nullTerminator != 0x00)
                         throw new NullTerminatorMissingException("Missing last null-terminator");
@@ -74,8 +95,11 @@ namespace RCONServerLib
             }
         }
 
-        public RemoteConPacket(int id, PacketType type, string payload)
+        public RemoteConPacket(int id, PacketType type, string payload, bool useUTF8 = false)
         {
+            if (useUTF8)
+                _packetEncoding = Encoding.UTF8;
+
             Payload = payload;
             Id = id;
             Type = type;
@@ -88,7 +112,7 @@ namespace RCONServerLib
         /// </summary>
         public int Length
         {
-            get { return Encoding.UTF8.GetBytes(Payload + '\0').Length + 13; }
+            get { return _packetEncoding.GetBytes(Payload + '\0').Length + 13; }
         }
 
         /// <summary>
@@ -101,7 +125,7 @@ namespace RCONServerLib
             {
                 using (var writer = new BinaryWriterExt(ms))
                 {
-                    var bodyBytes = Encoding.UTF8.GetBytes(Payload + '\0');
+                    var bodyBytes = _packetEncoding.GetBytes(Payload + '\0');
                     writer.WriteLittleEndian(bodyBytes.Length + 9);
                     writer.WriteLittleEndian(Id);
                     writer.WriteLittleEndian((int) Type);

--- a/RCONServerLib/RemoteConServer.cs
+++ b/RCONServerLib/RemoteConServer.cs
@@ -20,6 +20,7 @@ namespace RCONServerLib
 
         public RemoteConServer(IPAddress bindAddress, int port)
         {
+            UseUTF8 = false;
             EmptyPayloadKick = true;
             EnableIpWhitelist = true;
             InvalidPacketKick = true;
@@ -49,6 +50,12 @@ namespace RCONServerLib
         /// <summary>
         /// </summary>
         public Dictionary<string, int> IpBanList { get; set; }
+
+        /// <summary>
+        ///     Whether to use UTF8 to encode packet payloads.
+        ///     Default: False
+        /// </summary>
+        public bool UseUTF8 { get; set; }
 
         /// <summary>
         ///     When true closes the connection if the payload of the packet is empty.

--- a/RCONServerLib/RemoteConTcpClient.cs
+++ b/RCONServerLib/RemoteConTcpClient.cs
@@ -207,7 +207,7 @@ namespace RCONServerLib
         {
             try
             {
-                var packet = new RemoteConPacket(rawPacket);
+                var packet = new RemoteConPacket(rawPacket, _remoteConServer.UseUTF8);
 
                 if (!_isUnitTest)
                     _remoteConServer.LogDebug(((IPEndPoint) _tcp.Client.RemoteEndPoint).Address + " sent packet " +
@@ -233,9 +233,9 @@ namespace RCONServerLib
                         Authenticated = true;
 
                         if (!_remoteConServer.SendAuthImmediately)
-                            SendPacket(new RemoteConPacket(packet.Id, RemoteConPacket.PacketType.ResponseValue, ""));
+                            SendPacket(new RemoteConPacket(packet.Id, RemoteConPacket.PacketType.ResponseValue, "", _remoteConServer.UseUTF8));
 
-                        SendPacket(new RemoteConPacket(packet.Id, RemoteConPacket.PacketType.ExecCommand, ""));
+                        SendPacket(new RemoteConPacket(packet.Id, RemoteConPacket.PacketType.ExecCommand, "", _remoteConServer.UseUTF8));
                         return;
                     }
 
@@ -256,9 +256,9 @@ namespace RCONServerLib
                                                   " entered wrong password!");
 
                     if (!_remoteConServer.SendAuthImmediately)
-                        SendPacket(new RemoteConPacket(packet.Id, RemoteConPacket.PacketType.ResponseValue, ""));
+                        SendPacket(new RemoteConPacket(packet.Id, RemoteConPacket.PacketType.ResponseValue, "", _remoteConServer.UseUTF8));
 
-                    SendPacket(new RemoteConPacket(-1, RemoteConPacket.PacketType.ExecCommand, ""));
+                    SendPacket(new RemoteConPacket(-1, RemoteConPacket.PacketType.ExecCommand, "", _remoteConServer.UseUTF8));
 
                     return;
                 }
@@ -297,7 +297,7 @@ namespace RCONServerLib
                 {
                     var result = _remoteConServer.ExecuteCustomCommandHandler(cmd, args);
                     SendPacket(new RemoteConPacket(packet.Id, RemoteConPacket.PacketType.ResponseValue,
-                        result));
+                        result, _remoteConServer.UseUTF8));
                     return;
                 }
 
@@ -305,14 +305,14 @@ namespace RCONServerLib
                 if (command == null)
                 {
                     SendPacket(new RemoteConPacket(packet.Id, RemoteConPacket.PacketType.ResponseValue,
-                        "Invalid command \"" + packet.Payload + "\""));
+                        "Invalid command \"" + packet.Payload + "\"", _remoteConServer.UseUTF8));
                 }
                 else
                 {
                     var commandResult = command.Handler(cmd, args);
                     // TODO: Split packets?
                     SendPacket(new RemoteConPacket(packet.Id, RemoteConPacket.PacketType.ResponseValue,
-                        commandResult));
+                        commandResult, _remoteConServer.UseUTF8));
                 }
             }
             catch (RconServerException)


### PR DESCRIPTION
This implements Unicode support and should be backwards compatible as valid ASCII is also valid UTF8. 

As UTF8 is not delimited by a `NUL` character, but to keep compatibility with ASCII a `NUL` character will still be added to strings when sending a packet and it will be ignored when receiving a packet.

A `NUL` character is also a valid character in a UTF8 string and as such the RconPacketTooLongTest failed after these changes. I then removed it as this is expected behavior and the RconPacketLengthTest and RconPacketNullTerminatorTest should cover incorrect packets.

I also encountered another socket dispose crash when running the test, so I fixed that as well.