### PR TITLE
Fixing invalid packet id, not matter if it's really invalid or not

### DIFF
--- a/RCONServerLib/RemoteConClient.cs
+++ b/RCONServerLib/RemoteConClient.cs
@@ -328,11 +328,14 @@ namespace RCONServerLib
                     return;
                 }
 
-                if (_requestedCommands.ContainsKey(packet.Id) &&
-                    packet.Type == RemoteConPacket.PacketType.ResponseValue)
+                if (_requestedCommands.ContainsKey(packet.Id) && packet.Type == RemoteConPacket.PacketType.ResponseValue)
+                {
                     _requestedCommands[packet.Id](packet.Payload);
+                }
                 else
+                {
                     Log("Got packet with invalid id " + packet.Id);
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
After i initially cloned the project and tested the examples, i noticed it will always tell me that i've got packet with invalid id.

I am not sure, but i think one lined if clause does not work with multiline condition put betwenn the () brackets. Probably a issue with inconsistent line endings when loading up the project in some cases.

I've removed the one-liner and the issue was gone.